### PR TITLE
Fixed: Obraining complex roots must return self

### DIFF
--- a/complex.lua
+++ b/complex.lua
@@ -234,8 +234,7 @@ function complex.New(nRe,nIm)
         Th = Th + AngStep
       end; return tRoots
     end; return nil
-  end
-  return self
+  end; return nil
 end
 
 local function StrValidateComplex(sStr)


### PR DESCRIPTION
It must not return self by default